### PR TITLE
Don't optout from python test adapter experiment

### DIFF
--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -43,12 +43,6 @@ export class ConfigManager {
 
         const pythonShimPath = path.join(workspace.root, ShimsWriter.RELATIVE_SHIMS_PATH, "python");
         vscode.workspace.getConfiguration().update("python.defaultInterpreterPath", pythonShimPath);
-
-        const experiments = vscode.workspace.getConfiguration("python.experiments");
-        const optOutFrom = experiments.get<string[]>("optOutFrom") || [];
-
-        experiments.update("optOutFrom", [...new Set([...optOutFrom, "pythonTestAdapter"])],
-            vscode.ConfigurationTarget.Global);
     }
 
     public setupTestMate() {

--- a/test/configManager.test.ts
+++ b/test/configManager.test.ts
@@ -91,21 +91,16 @@ describe("configManager", () => {
             await subject.setupPythonExtension();
 
             m.workspaceConfiguration.verify((x) => x.update("python.defaultInterpreterPath", It.isAny()), Times.never());
-            m.workspaceConfiguration.verify((x) => x.update("optOutFrom", It.isAny(), It.isAny()), Times.never());
         })
         it("sets the default python interpreter", async () => {
             builder.fs.mkdir(".autoproj", "bin");
             builder.fs.mkfile("", ".autoproj", "bin", "python");
 
             m.getConfiguration.setup((x) => x()).returns(() => m.workspaceConfiguration.object);
-            m.getConfiguration.setup((x) => x("python.experiments")).returns(() => m.workspaceConfiguration.object);
-            m.workspaceConfiguration.setup((x) => x.get<string[]>("optOutFrom")).returns(() => ["foobar"]);
             await subject.setupPythonExtension();
 
             const pythonShimPath = path.join(builder.root, shims.ShimsWriter.RELATIVE_SHIMS_PATH, "python");
             m.workspaceConfiguration.verify((x) => x.update("python.defaultInterpreterPath", pythonShimPath), Times.once());
-            m.workspaceConfiguration.verify((x) => x.update("optOutFrom",
-                ["foobar", "pythonTestAdapter"], vscode.ConfigurationTarget.Global), Times.once());
         })
     });
     describe("setupRubyExtension()", () => {


### PR DESCRIPTION
It works now. Users can still optout if they want to.